### PR TITLE
fix: use correct input for org in folder request

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
         authResponse=$(curl -s -X POST "$orchestratorURL/identity_/connect/token" -H "${headers[@]}" -d "$body")
         accessToken=$(echo "$authResponse" | jq -r '.access_token')
 
-        if [ "$accessToken" == "null" ]; then
+        if [ -z "$accessToken" ] || [ "$accessToken" == "null" ]; then
           echo "Error: Failed to obtain access token. Response: $authResponse"
           exit 1
         fi
@@ -71,13 +71,23 @@ runs:
         echo $encodedParameters
 
         folderRequestURL="$orchestratorURL/${{ inputs.organizationId }}/${{ inputs.orchestratorTenant }}/orchestrator_/odata/folders?$encodedParameters"
+        echo "Requesting folder ID from URL: $folderRequestURL"
         folderRequestHeaders=("Authorization: Bearer $accessToken")
         
-        # Get folder ID
-        folderRequestResponse=$(curl -s -X GET "$folderRequestURL" -H "${folderRequestHeaders[@]}")
-        echo "$folderRequestResponse"
-        folderId=$(echo "$folderRequestResponse" | jq -r '.value[0].Id')
-        echo "folderId=$folderId" >> $GITHUB_OUTPUT
+        # Make the request and capture both the response and the HTTP status code
+        folderRequestResponse=$(curl -s -w "%{http_code}" -o response_body.txt -X GET "$folderRequestURL" -H "${folderRequestHeaders[@]}")
+        httpStatus=$(tail -c 3 <<< "$folderRequestResponse")
+        responseBody=$(cat response_body.txt)
+        echo "GET Folder response: $responseBody"
+
+        # Check if the status code is not 200
+        if [ "$httpStatus" -ne 200 ]; then
+          echo "Warning: GET folder request failed with status code $httpStatus. Response: $responseBody"
+        else
+          folderId=$(echo "$responseBody" | jq -r '.value[0].Id')
+          echo "folderId=$folderId" >> $GITHUB_OUTPUT
+        fi
+        
 
     - id: run_tests
       name: Test

--- a/action.yml
+++ b/action.yml
@@ -206,5 +206,5 @@ runs:
         
         echo -e "$testResults" >> $GITHUB_STEP_SUMMARY
 
-        echo "${{ steps.run_tests.outputs.testExecutionLinks }}"
-        echo "${{ steps.run_tests.outputs.testResults }}"
+        echo "$testExecutionLinks"
+        echo "$testResults"

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,8 @@ runs:
         body="grant_type=client_credentials&client_id=$clientId&client_secret=$clientSecret&scope=$scope"
         authResponse=$(curl -s -X POST "$orchestratorURL/identity_/connect/token" -H "${headers[@]}" -d "$body")
         accessToken=$(echo "$authResponse" | jq -r '.access_token')
+        echo "::add-mask::$accessToken"
+        echo Authentication response: "$authResponse"
 
         if [ -z "$accessToken" ] || [ "$accessToken" == "null" ]; then
           echo "Error: Failed to obtain access token. Response: $authResponse"

--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,7 @@ runs:
         echo $encodedParameters
 
         folderRequestURL="$orchestratorURL/${{ inputs.organizationId }}/${{ inputs.orchestratorTenant }}/orchestrator_/odata/folders?$encodedParameters"
-        folderRequestHeaders=("Authorization: Bearer ${{ steps.get-orchestrator-token.outputs.accessToken }}")
+        folderRequestHeaders=("Authorization: Bearer $accessToken")
         
         # Get folder ID
         folderRequestResponse=$(curl -s -X GET "$folderRequestURL" -H "${folderRequestHeaders[@]}")

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ runs:
         encodedParameters=$(jq -rn --arg params "$parameters" '$params | @uri')
         echo $encodedParameters
 
-        folderRequestURL="$orchestratorURL/${{ inputs.organizationId }}/${{ inputs.orchestratorTenant }}/orchestrator_/odata/folders?$encodedParameters"
+        folderRequestURL="$orchestratorURL/${{ inputs.orchestratorLogicalName }}/${{ inputs.orchestratorTenant }}/orchestrator_/odata/folders?$encodedParameters"
         echo "Requesting folder ID from URL: $folderRequestURL"
         folderRequestHeaders=("Authorization: Bearer $accessToken")
         

--- a/action.yml
+++ b/action.yml
@@ -74,20 +74,22 @@ runs:
         echo "Requesting folder ID from URL: $folderRequestURL"
         folderRequestHeaders=("Authorization: Bearer $accessToken")
         
-        # Make the request and capture both the response and the HTTP status code
-        folderRequestResponse=$(curl -s -w "%{http_code}" -o response_body.txt -X GET "$folderRequestURL" -H "${folderRequestHeaders[@]}")
-        httpStatus=$(tail -c 3 <<< "$folderRequestResponse")
+        # Make the request and capture the response and status code
+        httpStatus=$(curl -s -o response_body.txt -w "%{http_code}" -X GET "$folderRequestURL" -H "${folderRequestHeaders[@]}")
         responseBody=$(cat response_body.txt)
-        echo "GET Folder response: $responseBody"
+
+        # Log the response and status code
+        echo "HTTP Status: $httpStatus"
+        echo "Response Body: $responseBody"
 
         # Check if the status code is not 200
         if [ "$httpStatus" -ne 200 ]; then
-          echo "Warning: GET folder request failed with status code $httpStatus. Response: $responseBody"
-        else
-          folderId=$(echo "$responseBody" | jq -r '.value[0].Id')
-          echo "folderId=$folderId" >> $GITHUB_OUTPUT
+          echo "Warning: Request failed with status code $httpStatus. Response: $responseBody"
+          exit 1
         fi
-        
+
+        folderId=$(echo "$responseBody" | jq -r '.value[0].Id')
+        echo "folderId=$folderId" >> $GITHUB_OUTPUT
 
     - id: run_tests
       name: Test

--- a/action.yml
+++ b/action.yml
@@ -75,6 +75,7 @@ runs:
         
         # Get folder ID
         folderRequestResponse=$(curl -s -X GET "$folderRequestURL" -H "${folderRequestHeaders[@]}")
+        echo "$folderRequestResponse"
         folderId=$(echo "$folderRequestResponse" | jq -r '.value[0].Id')
         echo "folderId=$folderId" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Use correct name for the UiPath organization used when requesting folder id to use when constructing test execution links.

Improve logging and error handling on failed API requests.