### PR TITLE
feat: add testResultsFolder output

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,4 @@ The example below illustrates how the action can be used for a repository of mul
 |**testExecutionLinks**|Comma-separated list of URLs to directly access the test execution(s) triggered by this action|
 |**testResults**|Markdown formatted table listing the tests that have been run and whether they passed or failed. Each project tested gets its table with a link to the test execution(s) in Orchestrator as part of its header. If no test cases were found for a project, nor set as publishable, a warning message is added.|
 |**containsPublishableTestCases**|Boolean value indicating whether any test cases set as publishable were found in the repository|
+|**testResultsFolder**|Path to the folder where the test result JSON files created by the UiPath CLI are stored. Can be used for further processing, such as uploading to Artifacts or sending to another action.|

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,11 @@ outputs:
   containsPublishableTestCases:
     description: 'Boolean value indicating whether any test cases set as publishable were found in the repository'
     value: ${{ steps.run_tests.outputs.containsPublishableTestCases }}
+  testResultsFolder:
+    description: |
+      Path to the folder where the test result JSON files created by the UiPath CLI are stored. 
+      Can be used for further processing, such as uploading to Artifacts or sending to another action.
+    value: ${{ steps.run_tests.outputs.testResultsFolder }}
 
 runs:
   using: "composite"


### PR DESCRIPTION
Add output testResultsFolder to the action, providing the path on the runner where the test result json files are stored to enable further processing of test results.

This will enable further processing of test results, such as uploading them to the Artifacts of a job for manual review.